### PR TITLE
Create setup function to replace tla

### DIFF
--- a/packages/coralite/package.json
+++ b/packages/coralite/package.json
@@ -35,7 +35,7 @@
     "test-e2e": "playwright test",
     "test-e2e-report": "playwright show-report",
     "test-e2e-ui": "playwright test --ui",
-    "server": "sirv dist --dev --port 3000",
+    "server": "sirv .html --dev --port 3000",
     "build": "premove dist && pnpm build-lib && pnpm build-plugins && pnpm build-types",
     "build-lib": "esbuild ./lib/index.js --bundle --target=esnext --external:esbuild --format=esm --outdir=dist/lib --platform=node --sourcemap",
     "build-plugins": "esbuild ./plugins/*.js --format=esm --outdir=dist/plugins --platform=node",

--- a/packages/coralite/plugins/define-component.js
+++ b/packages/coralite/plugins/define-component.js
@@ -7,7 +7,7 @@ import {
 } from '#lib'
 
 /**
- * @import { CoraliteElement, CoraliteModuleScript, CoraliteModuleValues } from '../types/index.js'
+ * @import { CoraliteElement, CoraliteModuleScript, CoraliteModuleSetup, CoraliteModuleValue, CoraliteModuleValues, CoraliteValues } from '../types/index.js'
  */
 
 /**
@@ -86,13 +86,15 @@ export const defineComponent = createPlugin({
    *   Computed slots for the component. These are functions that define
    *   how content should be rendered within the component.
    * @param {CoraliteModuleScript} [options.script] - Script that will be added below the element.
+   * @param {CoraliteModuleSetup} [options.setup] - Setup function
    * @returns {Promise<CoraliteModuleValues>} A promise resolving to the module values
    *   associated with this component.
    */
   async method ({
     tokens,
     slots,
-    script
+    script,
+    setup
   },
   {
     values,
@@ -101,7 +103,13 @@ export const defineComponent = createPlugin({
     excludeByAttribute
   }) {
     /** @type {CoraliteModuleValues} */
-    const results = { ...values }
+    let results = { ...values }
+
+    if (setup) {
+      const initialValues = await setup(results)
+
+      results = Object.assign(results, initialValues)
+    }
 
     if (typeof tokens === 'object' && tokens !== null) {
       for (const key in tokens) {
@@ -212,7 +220,7 @@ export const defineComponent = createPlugin({
       const scriptTextContent = script.toString().trim()
 
       // include values used in script
-      /** @type {CoraliteModuleValues} */
+      /** @type {Object.<string, CoraliteModuleValue>} */
       const args = {}
       for (const key in results) {
         if (!Object.hasOwn(results, key)) continue

--- a/packages/coralite/tests/e2e/component.js
+++ b/packages/coralite/tests/e2e/component.js
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Component', () => {
+  test.describe('Setup Function', () => {
+    test('should resolve async data and pass values to client', async ({ page }) => {
+      await page.goto('/script-setup.html')
+
+      // First instance (default prop)
+      const first = page.locator('.setup-async').first()
+      const message1 = first.locator('span[data-coralite-ref="message"]')
+      const prop1 = first.locator('span[data-coralite-ref="prop"]')
+      const clientMsg1 = first.locator('span[data-coralite-ref="client-msg"]')
+
+      await expect(message1).toHaveText('Resolved')
+      await expect(prop1).toHaveText('default')
+      await expect(clientMsg1).toHaveText('passed-to-client')
+
+      // Second instance (custom prop)
+      const second = page.locator('.setup-async').nth(1)
+      const message2 = second.locator('span[data-coralite-ref="message"]')
+      const prop2 = second.locator('span[data-coralite-ref="prop"]')
+      const clientMsg2 = second.locator('span[data-coralite-ref="client-msg"]')
+
+      await expect(message2).toHaveText('Resolved')
+      await expect(prop2).toHaveText('custom')
+      await expect(clientMsg2).toHaveText('passed-to-client')
+    })
+  })
+})

--- a/packages/coralite/tests/fixtures/pages/setup-async.html
+++ b/packages/coralite/tests/fixtures/pages/setup-async.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Script Setup Test</title>
+</head>
+
+<body>
+  <h1>Script Setup Test</h1>
+  <coralite-setup-async></coralite-setup-async>
+
+  <coralite-setup-async my-prop="custom"></coralite-setup-async>
+</body>
+
+</html>

--- a/packages/coralite/tests/fixtures/templates/components/setup-async.html
+++ b/packages/coralite/tests/fixtures/templates/components/setup-async.html
@@ -1,0 +1,32 @@
+<template id="coralite-setup-async">
+  <div class="setup-async">
+    <p>Message: <span data-coralite-ref="message">{{ message }}</span></p>
+    <p>Prop: <span data-coralite-ref="prop">{{ propValue }}</span></p>
+    <p>Client: <span data-coralite-ref="client-msg">-</span></p>
+  </div>
+</template>
+
+<script type="module">
+  import { defineComponent } from 'coralite'
+
+  const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+  export default defineComponent({
+    // New setup function replacing TLA
+    async setup(values) {
+      await delay(50)
+      return {
+        message: 'Resolved',
+        propValue: values.myProp || 'default',
+        serverValue: 'passed-to-client'
+      }
+    },
+    // Client-side script receiving values from setup
+    script({ values }, { refs }) {
+      const clientMsg = refs('client-msg')
+      if (clientMsg) {
+        clientMsg.textContent = values.serverValue
+      }
+    }
+  })
+</script>

--- a/packages/coralite/types/index.js
+++ b/packages/coralite/types/index.js
@@ -376,6 +376,11 @@
  * @param {CoraliteRef} refs - References template elements
  */
 
+/**
+ * @callback CoraliteModuleSetup
+ * @param {CoraliteModuleValues} context
+ */
+
 
 /**
  * @typedef {Object} ScriptPlugin


### PR DESCRIPTION
Added support for an optional `setup` function in the `defineComponent` plugin. This function allows for initial value computation before the main component logic runs. The setup function receives the current module context values and can return additional or modified values, which are then merged into the results.